### PR TITLE
Fixed bug for invalid slide count when the preamble is missing

### DIFF
--- a/solardoc/asciidoc-renderer/src/presentation.ts
+++ b/solardoc/asciidoc-renderer/src/presentation.ts
@@ -90,7 +90,7 @@ export class Presentation {
     type MinReqAbstractBlock = Pick<AbstractBlock, 'getContext' | 'getBlocks'>
 
     let slides = <Array<MinReqAbstractBlock>>document.getBlocks();
-    const preambleExists = slides[0].getContext() === 'preamble';
+    const preambleExists = slides[0]?.getContext() === 'preamble';
     if (!preambleExists) {
       slides = [
         {

--- a/solardoc/asciidoc-renderer/src/presentation.ts
+++ b/solardoc/asciidoc-renderer/src/presentation.ts
@@ -87,13 +87,26 @@ export class Presentation {
    * @since 0.2.0
    */
   private getDocumentMetadata(document: Asciidoctor.Document): PresentationMetadata {
-    const slides = <Array<AbstractBlock>>document.getBlocks();
-    const subslideCountPerSlide = slides.map((slide: AbstractBlock) => {
-      let subBlocks = <Array<AbstractBlock>>slide.getBlocks();
-      return subBlocks.filter((block: AbstractBlock) => block.getContext() === 'section').length;
+    type MinReqAbstractBlock = Pick<AbstractBlock, 'getContext' | 'getBlocks'>
+
+    let slides = <Array<MinReqAbstractBlock>>document.getBlocks();
+    const preambleExists = slides[0].getContext() === 'preamble';
+    if (!preambleExists) {
+      slides = [
+        {
+          getContext: () => 'preamble',
+          getBlocks: () => []
+        },
+        ...slides
+      ]
+    }
+
+    const subslideCountPerSlide = slides.map((slide: MinReqAbstractBlock) => {
+      let subBlocks = <Array<AbstractBlock>>slide.getBlocks()
+      return subBlocks.filter((block: AbstractBlock) => block.getContext() === 'section').length
     })
-    const slideCount = slides.length;
-    const slideCountInclSubslides = subslideCountPerSlide.reduce((a, b) => a + b, slideCount);
+    const slideCount = subslideCountPerSlide.length
+    const slideCountInclSubslides = subslideCountPerSlide.reduce((a, b) => a + b, slideCount)
 
     return {
       title: document.getDocumentTitle(),

--- a/test/modules/asciidoc-renderer/presentation.test.ts
+++ b/test/modules/asciidoc-renderer/presentation.test.ts
@@ -97,5 +97,21 @@ describe("Presentation", () => {
       assert.equal(presentation.metadata.slideCount,4);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 2, 2, 0]);
     });
+
+    it("should return proper metadata when the first slide is empty and there are multiple slides & sub-slides", async () => {
+      const adocString =
+        `= Test\n\n== Still testing\n\nMain-Slide 2\n\n=== Still testing\n\nSub-Slide 2.1\n\n=== Still testing Sub-Slide 2.2\n\n== Still testing\n\nMain Slide-3\n\n=== Still testing Sub-Slide 3.1\n\nx\n\n=== Still testing Sub-Slide 3.2\n\nx\n\n== Still testing\n\n Main Slide-4\n\n`;
+      const adocFilename = "test.adoc";
+      const adocFile = await AsciidocFile.fromString(
+        adocFilename,
+        adocString,
+      );
+      const asciidocCompiler = new AsciidocCompiler();
+      const presentation = await asciidocCompiler.parse(adocFile);
+      assert.equal(presentation.metadata.title, "Test");
+      assert.equal(presentation.metadata.slideCountInclSubslides,8 );
+      assert.equal(presentation.metadata.slideCount,4);
+      assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 2, 2, 0]);
+    });
   });
 });


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug for invalid slide count when the preamble is missing.

<!-- Uncomment if this closes an issue:
Closes #INSERT_NR
-->

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Fixed bug for the metadata properties `slideCount`, `slideCountInclSubslides` and `subslideCountPerSlide` being incorrect when the preamble is missing.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Just write none if they are no warnings, like this:
None.
-->

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

No linked issues.
