### PR TITLE
Fixed presentation metadata bug

### DIFF
--- a/solardoc/asciidoc-renderer/src/presentation-metadata.ts
+++ b/solardoc/asciidoc-renderer/src/presentation-metadata.ts
@@ -38,4 +38,12 @@ export interface PresentationMetadata {
    * @since 0.3.0
    */
   subslideCountPerSlide: number[];
+
+  /**
+   * Returns true if the {@link title} is "Untitled Presentation".
+   *
+   * This is the default title that is used by SolarDoc if no title is specified in the asciidoc file.
+   * @since 0.3.1
+   */
+  defaultTitle: boolean;
 }

--- a/solardoc/asciidoc-renderer/src/presentation.ts
+++ b/solardoc/asciidoc-renderer/src/presentation.ts
@@ -4,6 +4,12 @@ import {PresentationMetadata} from './presentation-metadata'
 import AbstractBlock = Asciidoctor.AbstractBlock;
 
 /**
+ * The default title that is used if no title is specified in the asciidoc file.
+ * @since 0.3.1
+ */
+export const DEFAULT_PRESENTATION_TITLE: string = "Unnamed Presentation"
+
+/**
  * A presentation is a collection of slides, which internally are reveal.js slides. These can be converted to HTML,
  * PDFs or images.
  * @since 0.2.0
@@ -113,8 +119,10 @@ export class Presentation {
     const slideCount = subslideCountPerSlide.length
     const slideCountInclSubslides = subslideCountPerSlide.reduce((a, b) => a + b, slideCount)
 
+    const title = document.getDocumentTitle() || DEFAULT_PRESENTATION_TITLE
     return {
-      title: document.getDocumentTitle(),
+      defaultTitle: title === DEFAULT_PRESENTATION_TITLE,
+      title: title,
       author: document.getAuthor(),
       slideCount: slideCount,
       slideCountInclSubslides: slideCountInclSubslides,

--- a/solardoc/asciidoc-renderer/src/presentation.ts
+++ b/solardoc/asciidoc-renderer/src/presentation.ts
@@ -87,15 +87,20 @@ export class Presentation {
    * @since 0.2.0
    */
   private getDocumentMetadata(document: Asciidoctor.Document): PresentationMetadata {
-    type MinReqAbstractBlock = Pick<AbstractBlock, 'getContext' | 'getBlocks'>
+    type MinReqAbstractBlock = Pick<AbstractBlock, 'getContext' | 'getBlocks' | 'getLevel'>
 
     let slides = <Array<MinReqAbstractBlock>>document.getBlocks();
     const preambleExists = slides[0]?.getContext() === 'preamble';
-    if (!preambleExists) {
+    const nonPreambleFirstSlideExists = !preambleExists && slides[0]?.getLevel() === 0;
+
+    // We have to also check for 'nonPreambleFirstSlideExists' because if the first slide is the only slide and it is
+    // also not a preamble slide but a standard slide (paragraphs in asciidoc).
+    if (!preambleExists && !nonPreambleFirstSlideExists) {
       slides = [
         {
           getContext: () => 'preamble',
-          getBlocks: () => []
+          getBlocks: () => [],
+          getLevel: () => 0
         },
         ...slides
       ]

--- a/test/modules/asciidoc-renderer/presentation.test.ts
+++ b/test/modules/asciidoc-renderer/presentation.test.ts
@@ -60,8 +60,8 @@ describe("Presentation", () => {
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
       assert.equal(presentation.metadata.title, "Test");
-      assert.equal(presentation.metadata.slideCountInclSubslides,5 );
-      assert.equal(presentation.metadata.slideCount,4);
+      assert.equal(presentation.metadata.slideCountInclSubslides, 5);
+      assert.equal(presentation.metadata.slideCount, 4);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 1, 0, 0]);
     });
 
@@ -77,8 +77,8 @@ describe("Presentation", () => {
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
       assert.equal(presentation.metadata.title, "Test");
-      assert.equal(presentation.metadata.slideCountInclSubslides,6 );
-      assert.equal(presentation.metadata.slideCount,4);
+      assert.equal(presentation.metadata.slideCountInclSubslides, 6);
+      assert.equal(presentation.metadata.slideCount, 4);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 2, 0, 0]);
     });
 
@@ -93,8 +93,8 @@ describe("Presentation", () => {
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
       assert.equal(presentation.metadata.title, "Test");
-      assert.equal(presentation.metadata.slideCountInclSubslides,8 );
-      assert.equal(presentation.metadata.slideCount,4);
+      assert.equal(presentation.metadata.slideCountInclSubslides, 8);
+      assert.equal(presentation.metadata.slideCount, 4);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 2, 2, 0]);
     });
 
@@ -109,9 +109,24 @@ describe("Presentation", () => {
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
       assert.equal(presentation.metadata.title, "Test");
-      assert.equal(presentation.metadata.slideCountInclSubslides,8 );
-      assert.equal(presentation.metadata.slideCount,4);
+      assert.equal(presentation.metadata.slideCountInclSubslides, 8);
+      assert.equal(presentation.metadata.slideCount, 4);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 2, 2, 0]);
+    });
+
+    it("should return proper metadata when the first slide is present but is the only slide", async () => {
+      const adocString = `= Test\n\n== Test\nx\n`;
+      const adocFilename = "test.adoc";
+      const adocFile = await AsciidocFile.fromString(
+        adocFilename,
+        adocString,
+      );
+      const asciidocCompiler = new AsciidocCompiler();
+      const presentation = await asciidocCompiler.parse(adocFile);
+      assert.equal(presentation.metadata.title, "Test");
+      assert.equal(presentation.metadata.slideCountInclSubslides, 1);
+      assert.equal(presentation.metadata.slideCount, 1);
+      assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0]);
     });
   });
 });

--- a/test/modules/asciidoc-renderer/presentation.test.ts
+++ b/test/modules/asciidoc-renderer/presentation.test.ts
@@ -1,4 +1,4 @@
-import {AsciidocCompiler, AsciidocFile} from "@solardoc/asciidoc-renderer";
+import {AsciidocCompiler, AsciidocFile, DEFAULT_PRESENTATION_TITLE} from "@solardoc/asciidoc-renderer";
 import {assert} from "chai";
 
 
@@ -42,6 +42,7 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
       assert.equal(presentation.metadata.slideCountInclSubslides, 4);
       assert.equal(presentation.metadata.slideCount, 4);
@@ -59,6 +60,7 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
       assert.equal(presentation.metadata.slideCountInclSubslides, 5);
       assert.equal(presentation.metadata.slideCount, 4);
@@ -76,6 +78,7 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
       assert.equal(presentation.metadata.slideCountInclSubslides, 6);
       assert.equal(presentation.metadata.slideCount, 4);
@@ -92,6 +95,7 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
       assert.equal(presentation.metadata.slideCountInclSubslides, 8);
       assert.equal(presentation.metadata.slideCount, 4);
@@ -108,6 +112,7 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
       assert.equal(presentation.metadata.slideCountInclSubslides, 8);
       assert.equal(presentation.metadata.slideCount, 4);
@@ -123,7 +128,24 @@ describe("Presentation", () => {
       );
       const asciidocCompiler = new AsciidocCompiler();
       const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isFalse(presentation.metadata.defaultTitle);
       assert.equal(presentation.metadata.title, "Test");
+      assert.equal(presentation.metadata.slideCountInclSubslides, 2);
+      assert.equal(presentation.metadata.slideCount, 2);
+      assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0, 0]);
+    });
+
+    it("should return proper metadata when there is only text with no headers to indicate slides", async () => {
+      const adocString = `Test`;
+      const adocFilename = "test.adoc";
+      const adocFile = await AsciidocFile.fromString(
+        adocFilename,
+        adocString,
+      );
+      const asciidocCompiler = new AsciidocCompiler();
+      const presentation = await asciidocCompiler.parse(adocFile);
+      assert.isTrue(presentation.metadata.defaultTitle);
+      assert.equal(presentation.metadata.title, DEFAULT_PRESENTATION_TITLE);
       assert.equal(presentation.metadata.slideCountInclSubslides, 1);
       assert.equal(presentation.metadata.slideCount, 1);
       assert.deepEqual(presentation.metadata.subslideCountPerSlide, [0]);


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed presentation metadata bug for the presentation slide count.

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Fixed bug where a single main slide causes an invalid slide count.
- Implemented default presentation title behaviour and new property `defaultTitle`.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

No linked issues.
