### PR TITLE
Fixed chrome gradient issue

### DIFF
--- a/solardoc/frontend/src/views/HomeView.vue
+++ b/solardoc/frontend/src/views/HomeView.vue
@@ -69,14 +69,14 @@ div#home-page {
         color: transparent;
 
         /* Here we apply a gradient which should be visible on WebKit & Moz browsers */
-        background: -webkit-linear-gradient(
-          90deg,
-          var.$scheme-cs-1,
-          var.$scheme-cs-2,
-          var.$scheme-cs-3,
-          var.$scheme-cs-4
-        );
         background: -moz-linear-gradient(
+                90deg,
+                var.$scheme-cs-1,
+                var.$scheme-cs-2,
+                var.$scheme-cs-3,
+                var.$scheme-cs-4
+        );
+        background: -webkit-linear-gradient(
           90deg,
           var.$scheme-cs-1,
           var.$scheme-cs-2,


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [X] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->
The gradient homepage text was invisible in the chromium browser, which got fixed by placing the ``` -moz-linear-gradient``` before the ```-webkit-linear-gradient```.

Closes #99

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- switched   ```-webkit-linear-gradient``` with ``` -moz-linear-gradient``` 

## Does this PR create new warnings?

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #99


