### PR TITLE
Made file name read-only in opened share files

### DIFF
--- a/solardoc/frontend/src/views/EditorView.vue
+++ b/solardoc/frontend/src/views/EditorView.vue
@@ -144,6 +144,7 @@ setInterval(updateLastModified, 500)
           <!-- @vue-ignore We need the value property and TypeScript can't find it so we have to force it -->
           <input
             id="file-name-input"
+            :disabled="currentFileStore.shareFile"
             v-model="currentFileStore.fileName"
             @input="event => currentFileStore.setFileName(event.target!.value)"
           />


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug where the editor file name was still editable despite accessing it through a ShareURL (As such there are no permissions to even do so).

Closes #167 

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Added check to the input element to check whether the file is a shared file.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #167 