### PR TITLE
Added check in ShareURLView.vue to avoid the owner viewing their own file as if they were a guest

### DIFF
--- a/solardoc/frontend/src/views/ShareURLView.vue
+++ b/solardoc/frontend/src/views/ShareURLView.vue
@@ -78,9 +78,16 @@ async function handleShareURLReq(shareUrlId: string): Promise<void> {
   if (!shareURL) {
     return
   }
-  currentFileStore.setFileFromShared(file, shareUrlId, <Permission>shareURL.perms)
+
+  // The owner themselves can use the share URL so we need to make sure they see it as it were their own file
+  const isShareFileOwner = currentUserStore.currentUser?.id === file.owner_id
+  if (isShareFileOwner) {
+    currentFileStore.setFile(file)
+  } else {
+    currentFileStore.setFileFromShared(file, shareUrlId, <Permission>shareURL.perms)
+  }
   loadingStore.setLoading(false)
-  await $router.push('/editor')
+  await $router.push({ path: '/editor', query: isShareFileOwner ? undefined : { shareId: shareUrlId }})
 }
 
 interceptErrors(handleShareURLReq(`${$route.params.shareUrlId}`))


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug where an owner accessing their own file through a ShareURL would get a share editor opened instead of a regular editor.

Closes #172 

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Added check in ShareURLView.vue to avoid the owner viewing their own file as if they were a guest.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #172 