### PR TITLE
Fixed bug of first time visitors incorrectly getting saved remotely shown as the file status

### DIFF
--- a/solardoc/frontend/src/components/editor/SaveStateBadge.vue
+++ b/solardoc/frontend/src/components/editor/SaveStateBadge.vue
@@ -5,11 +5,11 @@ import constants from '@/plugins/constants'
 const currentFileStore = useCurrentFileStore()
 
 function getSaveStateCSSClass() {
-  return currentFileStore.saveState ? (currentFileStore.shareFile ? 'shared' : 'saved') : 'error'
+  return currentFileStore.remoteFile ? (currentFileStore.shareFile ? 'shared' : 'saved') : 'error'
 }
 
 function getSaveState() {
-  return currentFileStore.saveState
+  return currentFileStore.remoteFile
     ? currentFileStore.shareFile
       ? constants.saveStates.shared
       : constants.saveStates.server

--- a/solardoc/frontend/src/stores/current-file.ts
+++ b/solardoc/frontend/src/stores/current-file.ts
@@ -61,7 +61,6 @@ export const useCurrentFileStore = defineStore('currentFile', {
       fileId: <string | undefined>storedFileId || undefined,
       fileName: storedFileName,
       ownerId: storedFileOwner || undefined,
-      saveState: storedFileId !== undefined,
       content: storedFileContent,
       oTransStack: new Map<string, OTrans>(),
       oTransNotAcked: new Map<string, OTransReqDto>(),
@@ -158,7 +157,6 @@ export const useCurrentFileStore = defineStore('currentFile', {
         return
       }
       await this.closeFile()
-      this.setOnlineSaveState(false)
     },
     async storeOnServer(bearer: string) {
       if (this.fileId === undefined) {
@@ -166,7 +164,6 @@ export const useCurrentFileStore = defineStore('currentFile', {
       } else {
         await this.updateFile(bearer)
       }
-      this.setOnlineSaveState(true)
     },
     async createFile(bearer: string) {
       let resp: Awaited<ReturnType<typeof phoenixRestService.postV1Files>>
@@ -307,15 +304,11 @@ export const useCurrentFileStore = defineStore('currentFile', {
       }
       this.setLastModified(new Date())
     },
-    setOnlineSaveState(value: boolean) {
-      this.saveState = value
-    },
     setFile(file: File, perm: Permission = Permissions.Unknown) {
       this.setFileId(file.id)
       this.setOwnerId(file.owner_id)
       this.setFileName(file.file_name)
       this.setContent(file.content)
-      this.setOnlineSaveState(true)
       this.setLastModified(new Date(file.last_edited))
       this.setPermissions(perm)
       this.setCreated(new Date(file.created))
@@ -393,7 +386,6 @@ export const useCurrentFileStore = defineStore('currentFile', {
       this.clearChannelId()
       this.clearShareURLId()
       this.setFileName(constants.defaultFileName)
-      this.setOnlineSaveState(false)
       this.setPermissions(Permissions.Unknown)
       this.resetLastModified()
       this.resetCreated()


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug of first time visitors incorrectly getting saved remotely shown as the file status.

Closes #182 

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

-  Replaced outdated property `saveState` with the getter `remoteFile`, which relies on the fileId being present i.e. the remote ID given when a file is saved on the server.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #182 
