### PR TITLE
Fixed bug of "New File" overwriting currently opened remotely opened file

### DIFF
--- a/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
@@ -39,7 +39,6 @@ function closeDropdown() {
 async function handleNewFileButtonClick() {
   closeDropdown()
   showDummyLoading()
-  await currentFileStore.closeFile()
   await closeEditorRemoteFileConnection()
   showInfoNotifFromObj(constants.notifMessages.newFile)
 }

--- a/solardoc/frontend/src/scripts/editor/editor.ts
+++ b/solardoc/frontend/src/scripts/editor/editor.ts
@@ -104,7 +104,11 @@ export class SolardocEditor {
     },
   ) {
     setUpMonaco()
-    globalMonacoEditor! = monaco.editor.create(elementToBindTo.value, {
+    if (globalMonacoEditor != null) {
+      this._destroy()
+    }
+
+    globalMonacoEditor = monaco.editor.create(elementToBindTo.value, {
       theme: initialState.darkMode ? 'asciiDocDarkTheme' : 'asciiDocLightTheme',
       language: 'asciiDoc',
       value: undefined,
@@ -116,6 +120,7 @@ export class SolardocEditor {
       automaticLayout: true,
       scrollBeyondLastLine: false,
     })
+
     // We need to set the content after the editor is created due to a weird bug in Monaco (See #146)
     this._applyInitContent(`${initialState.content}` || '')
     this._locked = false
@@ -279,5 +284,15 @@ export class SolardocEditor {
       monaco.editor.remeasureFonts()
       this.forceRerender()
     })
+  }
+
+  /**
+   * @since 1.0.0
+   * @private
+   */
+  private static _destroy(): void {
+    globalMonacoEditor?.setModel(null)
+    globalMonacoEditor?.dispose()
+    globalMonacoEditor = null
   }
 }

--- a/solardoc/frontend/src/scripts/editor/file.ts
+++ b/solardoc/frontend/src/scripts/editor/file.ts
@@ -42,17 +42,19 @@ export async function openFileInEditor($router: Router, file: File): Promise<voi
 
 /**
  * Close the current remote file connection and resets all file-related stores.
+ *
+ * If there was no websocket connection, we will still reset the file store just to be safe.
  * @returns True if the connection was closed, false otherwise. (e.g. no connection was present)
  * @since 0.7.0
  */
 export async function closeEditorRemoteFileConnection(): Promise<boolean> {
-  if (!editorUpdateWSClient.wsClient) {
-    return false
-  }
   overlayStateStore.resetAll()
   await currentFileStore.closeFile()
-  await editorUpdateWSClient.disconnectWSClient()
-  return true
+  if (editorUpdateWSClient.wsClient) {
+    await editorUpdateWSClient.disconnectWSClient()
+    return true
+  }
+  return false
 }
 
 /**

--- a/solardoc/frontend/src/stores/current-file.ts
+++ b/solardoc/frontend/src/stores/current-file.ts
@@ -379,6 +379,14 @@ export const useCurrentFileStore = defineStore('currentFile', {
         permissions ? String(permissions) : '',
       )
     },
+    /**
+     * Closes the file and resets the entire store.
+     *
+     * DANGEROUS FUNCTION: This will clear the entire store and reset it to the default state. If you are still hooked
+     * to the editor and potentially are still in a sync channel with the server, this will overwrite all of that!
+     * @param preserveContent If true, the content will not be reset to the default content.
+     * @since 0.
+     */
     async closeFile(preserveContent: boolean = false) {
       this.clearFileId()
       this.clearOTransStack()


### PR DESCRIPTION
…te file state

<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug of "New File" overwriting currently opened remotely opened file.

Closes #188 

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Removed store reset in `EditorSandwichDropdown.vue`, which triggered an update in the editor even when the channel was still connected. This caused the channel to send the store reset to the server as well destroying the remote state.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #188 
