### PR TITLE
Fixed bug that files larger than 255 bytes can't be uploaded or saved to the DB

### DIFF
--- a/solardoc/phoenix-server/priv/repo/migrations/20240620091923_remove_file_content_length_limit.exs
+++ b/solardoc/phoenix-server/priv/repo/migrations/20240620091923_remove_file_content_length_limit.exs
@@ -1,0 +1,9 @@
+defmodule SolardocPhoenix.Repo.Migrations.RemoveFileContentLengthLimit do
+  use Ecto.Migration
+
+  def change do
+    alter table(:files) do
+      modify :content, :text
+    end
+  end
+end

--- a/solardoc/phoenix-server/priv/repo/migrations/20240620093347_make_file_name_required.exs
+++ b/solardoc/phoenix-server/priv/repo/migrations/20240620093347_make_file_name_required.exs
@@ -1,0 +1,9 @@
+defmodule SolardocPhoenix.Repo.Migrations.MakeFileNameRequired do
+  use Ecto.Migration
+
+  def change do
+    alter table(:files) do
+      modify :file_name, :string, null: false
+    end
+  end
+end


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug that files larger than 255 bytes can't be uploaded or saved to the DB. That meant files larger than that were only stored in the Phoenix runtime cache.

Closes #202 

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Created migration to change the datatype of `content` from `string` to `text`.
- Created migration to make field `file_name` not nullable.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #202 