### PR TITLE
Fixed default slide manager scroll bug

### DIFF
--- a/solardoc/frontend/src/components/editor/sub-views/default/slides-navigator/SlidesNavigator.vue
+++ b/solardoc/frontend/src/components/editor/sub-views/default/slides-navigator/SlidesNavigator.vue
@@ -54,6 +54,6 @@ watch(globalX, () => {
   width: var.$editor-preview-slides-navigator-width;
 
   // This element will be scrolled but by the sub-slides-navigator (weird workaround but it works)
-  overflow: hidden;
+  overflow: scroll hidden;
 }
 </style>


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] Feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

The default slide preview was only scrollable through the subslide-preview. 
To solve this the overflow of the slide manager was changed from hidden to hidden show.

Closes #249

## List of Changes

-  Changed the overflow of the slide manager to be hidden.

## Does this PR create new warnings?

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [ ] #249

<!-- Just write the following if there are no linked issues:
No linked issues.
-->
