### PR TITLE
Implemented proper separation of local, remote and shared files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,11 @@ services:
       PHX_BASE_PATH: ${PHX_BASE_PATH}
       PHX_WS_PATH: ${PHX_WS_PATH}
       NODE_ENV: production
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     depends_on:
       - rest-api
       - phoenix-server
@@ -46,6 +51,11 @@ services:
       PERSISTENT_STORAGE_PATH: ${PERSISTENT_STORAGE_PATH}
       PUPPETEER_SKIP_DOWNLOAD: "true"
       NODE_ENV: production
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/3000; exit $?;'"
+      interval: 10s
+      timeout: 10s
+      retries: 3
     volumes:
       - rest-api-persistent-storage:${PERSISTENT_STORAGE_PATH}
     depends_on:
@@ -62,6 +72,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgresql-db:5432/${POSTGRES_DB}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
       PORT: 4000
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/4000; exit $?;'"
+      interval: 10s
+      timeout: 10s
+      retries: 3
     depends_on:
       postgresql-db:
         condition: service_healthy
@@ -111,6 +126,11 @@ services:
     build: ./solardoc/postgres-adminer
     ports:
       - "8081:8080"
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/8080; exit $?;'"
+      interval: 10s
+      timeout: 10s
+      retries: 3
     environment:
       ADMINER_DESIGN: 'hydra'
     restart: always

--- a/solardoc/frontend/src/App.vue
+++ b/solardoc/frontend/src/App.vue
@@ -7,7 +7,12 @@ import Navbar from '@/components/navbar/Navbar.vue'
 import Footer from '@/components/Footer.vue'
 import { Notifications } from '@kyvg/vue3-notification'
 
-const NO_FOOTER_OR_STYLED_NAV_ROUTES = ['test-editor', 'editor']
+const NO_FOOTER_OR_STYLED_NAV_ROUTES = [
+  'test-editor',
+  'local-editor',
+  'remote-editor',
+  'shared-editor',
+]
 
 const darkModeStore = useDarkModeStore()
 darkModeStore.setThemeOnHTMLRoot()

--- a/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
@@ -14,10 +14,7 @@ import { useLoadingStore } from '@/stores/loading'
 import constants from '@/plugins/constants'
 import { useRouter } from 'vue-router'
 import { ref } from 'vue'
-import {
-  closeEditorRemoteFileConnection,
-  createEditorRemoteFileConnection,
-} from '@/scripts/editor/file'
+import { createEditorRemoteFileConnection } from '@/scripts/editor/file'
 import { handleCopy } from '@/scripts/handle-copy'
 import { openInNewWindow } from '@/router/open'
 

--- a/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
@@ -19,7 +19,7 @@ import {
   createEditorRemoteFileConnection,
 } from '@/scripts/editor/file'
 import { handleCopy } from '@/scripts/handle-copy'
-import {openInNewWindow} from "@/router/open";
+import { openInNewWindow } from '@/router/open'
 
 const darkModeStore = useDarkModeStore()
 const currentUserStore = useCurrentUserStore()
@@ -40,7 +40,7 @@ function closeDropdown() {
 
 function handleNewFileButtonClick() {
   closeDropdown()
-  openInNewWindow($router, {name: 'local-editor', query: {'new': 'true'}})
+  openInNewWindow($router, { name: 'local-editor', query: { new: 'true' } })
 }
 
 async function handleSaveButtonClick() {

--- a/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/EditorSandwichDropdown.vue
@@ -19,6 +19,7 @@ import {
   createEditorRemoteFileConnection,
 } from '@/scripts/editor/file'
 import { handleCopy } from '@/scripts/handle-copy'
+import {openInNewWindow} from "@/router/open";
 
 const darkModeStore = useDarkModeStore()
 const currentUserStore = useCurrentUserStore()
@@ -37,11 +38,9 @@ function closeDropdown() {
   )?.close()
 }
 
-async function handleNewFileButtonClick() {
+function handleNewFileButtonClick() {
   closeDropdown()
-  showDummyLoading()
-  await closeEditorRemoteFileConnection()
-  showInfoNotifFromObj(constants.notifMessages.newFile)
+  openInNewWindow($router, {name: 'local-editor', query: {'new': 'true'}})
 }
 
 async function handleSaveButtonClick() {

--- a/solardoc/frontend/src/components/editor/dropdown/editor-settings/CollaboratorList.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/editor-settings/CollaboratorList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useCurrentFileStore } from '@/stores/current-file'
 import { ref } from 'vue'
+import type { FilePermission, FilePermissions } from '@/services/phoenix/api-service'
 import * as phoenixRestService from '@/services/phoenix/api-service'
 import { useCurrentUserStore } from '@/stores/current-user'
 import type { Awaited } from '@vueuse/core'
@@ -10,7 +11,6 @@ import {
   PhoenixInternalError,
 } from '@/services/phoenix/errors'
 import CollaboratorCard from '@/components/editor/dropdown/editor-settings/CollaboratorCard.vue'
-import type { FilePermission, FilePermissions } from '@/services/phoenix/api-service'
 
 const currentFileStore = useCurrentFileStore()
 const currentUserStore = useCurrentUserStore()

--- a/solardoc/frontend/src/components/editor/dropdown/editor-settings/EditorSettings.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/editor-settings/EditorSettings.vue
@@ -20,6 +20,7 @@ import { ensureLoggedIn } from '@/scripts/ensure-logged-in'
 import { showInfoNotifFromObj } from '@/scripts/show-notif'
 import constants from '@/plugins/constants'
 import { useRouter } from 'vue-router'
+import {waitForConditionAndExecute} from "@/scripts/wait-for";
 
 const $router = useRouter()
 
@@ -29,10 +30,13 @@ const currentUserStore = useCurrentUserStore()
 const owner = ref<UserPublic>()
 
 ;(async () => {
-  if (currentUserStore.loggedIn && currentFileStore.remoteFile) {
-    await fetchOwner(currentFileStore.ownerId!, currentUserStore.bearer!)
-  } else {
-    owner.value = { username: 'Local User', id: 'local-user-id' }
+  owner.value = { username: 'Local User', id: 'local-user-id' }
+  if (currentUserStore.loggedIn && !!currentUserStore.bearer) {
+    await waitForConditionAndExecute(
+      () => currentFileStore.remoteFile && !!currentFileStore.ownerId,
+      async () => await fetchOwner(currentFileStore.ownerId!, currentUserStore.bearer!),
+      500,
+    )
   }
 })()
 

--- a/solardoc/frontend/src/components/editor/dropdown/editor-settings/EditorSettings.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/editor-settings/EditorSettings.vue
@@ -8,19 +8,19 @@ import { useCurrentUserStore } from '@/stores/current-user'
 import CollaboratorList from '@/components/editor/dropdown/editor-settings/CollaboratorList.vue'
 import UserRef from '@/components/common/UserRef.vue'
 import type { Awaited } from '@vueuse/core'
+import type { UserPublic } from '@/services/phoenix/api-service'
 import * as phoenixRestService from '@/services/phoenix/api-service'
 import {
   type ActualPhxErrorResp,
   PhoenixBadRequestError,
   PhoenixInternalError,
 } from '@/services/phoenix/errors'
-import type { UserPublic } from '@/services/phoenix/api-service'
 import { interceptErrors } from '@/errors/handler/error-handler'
 import { ensureLoggedIn } from '@/scripts/ensure-logged-in'
 import { showInfoNotifFromObj } from '@/scripts/show-notif'
 import constants from '@/plugins/constants'
 import { useRouter } from 'vue-router'
-import {waitForConditionAndExecute} from "@/scripts/wait-for";
+import { waitForConditionAndExecute } from '@/scripts/wait-for'
 
 const $router = useRouter()
 

--- a/solardoc/frontend/src/components/editor/dropdown/share-url/ShareUrlCreate.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/share-url/ShareUrlCreate.vue
@@ -9,9 +9,9 @@ import { useCurrentFileStore } from '@/stores/current-file'
 import * as phoenixRestService from '@/services/phoenix/api-service'
 import { PhoenixInternalError, PhoenixRestError } from '@/services/phoenix/errors'
 import { ref } from 'vue'
+import type { GradientType, RenderAs } from 'qrcode.vue'
 import QrcodeVue from 'qrcode.vue'
-import type { RenderAs, GradientType } from 'qrcode.vue'
-import {useRouter} from "vue-router";
+import { useRouter } from 'vue-router'
 
 const $router = useRouter()
 
@@ -61,10 +61,13 @@ async function submitForm(
         throw new PhoenixRestError('Server rejected request to fetch current user', resp.status)
       }
       if (resp.status === 201) {
-        generatedLink.value = $router.resolve({
+        const location = $router.resolve({
           name: 'shared-editor',
           params: { fileId: resp.data.id },
-        }).href
+        })
+        generatedLink.value = location.href.includes(window.location.origin)
+          ? location.href
+          : `${window.location.origin}${location.href}`
       }
     }
   }

--- a/solardoc/frontend/src/components/editor/dropdown/share-url/ShareUrlCreate.vue
+++ b/solardoc/frontend/src/components/editor/dropdown/share-url/ShareUrlCreate.vue
@@ -11,6 +11,9 @@ import { PhoenixInternalError, PhoenixRestError } from '@/services/phoenix/error
 import { ref } from 'vue'
 import QrcodeVue from 'qrcode.vue'
 import type { RenderAs, GradientType } from 'qrcode.vue'
+import {useRouter} from "vue-router";
+
+const $router = useRouter()
 
 const overlayStateStore = useOverlayStateStore()
 const currentUserStore = useCurrentUserStore()
@@ -58,7 +61,10 @@ async function submitForm(
         throw new PhoenixRestError('Server rejected request to fetch current user', resp.status)
       }
       if (resp.status === 201) {
-        generatedLink.value = `${window.location.origin}/share/${resp.data.id}`
+        generatedLink.value = $router.resolve({
+          name: 'shared-editor',
+          params: { fileId: resp.data.id },
+        }).href
       }
     }
   }

--- a/solardoc/frontend/src/components/editor/export/Export.vue
+++ b/solardoc/frontend/src/components/editor/export/Export.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import JSZip from 'jszip'
 import { useOverlayStateStore } from '@/stores/overlay-state'
 import CloseButtonSVG from '@/components/icons/CloseButtonSVG.vue'

--- a/solardoc/frontend/src/errors/file-not-found-error.ts
+++ b/solardoc/frontend/src/errors/file-not-found-error.ts
@@ -1,0 +1,20 @@
+import { SolardocError } from '@/errors/solardoc-error'
+
+/**
+ * Error class for when a file is not found in the Kipper system.
+ * @since 1.0.0
+ */
+export class KipperFileNotFoundError extends SolardocError {
+  constructor(
+    message: string = 'The requested file was not found.',
+    description: string = 'The file you are looking for does not exist or has been moved. Please check the file path and try again.'
+  ) {
+    super(
+      'KipperFileNotFoundError',
+      message,
+      'File Not Found',
+      message,
+      description,
+    )
+  }
+}

--- a/solardoc/frontend/src/errors/file-not-found-error.ts
+++ b/solardoc/frontend/src/errors/file-not-found-error.ts
@@ -7,14 +7,8 @@ import { SolardocError } from '@/errors/solardoc-error'
 export class KipperFileNotFoundError extends SolardocError {
   constructor(
     message: string = 'The requested file was not found.',
-    description: string = 'The file you are looking for does not exist or has been moved. Please check the file path and try again.'
+    description: string = 'The file you are looking for does not exist or has been moved. Please check the file path and try again.',
   ) {
-    super(
-      'KipperFileNotFoundError',
-      message,
-      'File Not Found',
-      message,
-      description,
-    )
+    super('KipperFileNotFoundError', message, 'File Not Found', message, description)
   }
 }

--- a/solardoc/frontend/src/errors/not-implemented-error.ts
+++ b/solardoc/frontend/src/errors/not-implemented-error.ts
@@ -1,0 +1,20 @@
+import { SolardocError } from '@/errors/solardoc-error'
+
+/**
+ * Error class for development or experimental features not being implemented.
+ * @since 1.0.0
+ */
+export class SolardocNotImplementedError extends SolardocError {
+  constructor(
+    message: string = 'This feature is not implemented yet.',
+    description: string = 'This feature is not implemented yet. Please check back later for updates.'
+  ) {
+    super(
+      'SolardocNotImplementedError',
+      message,
+      'Not Implemented',
+      message,
+      description,
+    )
+  }
+}

--- a/solardoc/frontend/src/errors/not-implemented-error.ts
+++ b/solardoc/frontend/src/errors/not-implemented-error.ts
@@ -7,14 +7,8 @@ import { SolardocError } from '@/errors/solardoc-error'
 export class SolardocNotImplementedError extends SolardocError {
   constructor(
     message: string = 'This feature is not implemented yet.',
-    description: string = 'This feature is not implemented yet. Please check back later for updates.'
+    description: string = 'This feature is not implemented yet. Please check back later for updates.',
   ) {
-    super(
-      'SolardocNotImplementedError',
-      message,
-      'Not Implemented',
-      message,
-      description,
-    )
+    super('SolardocNotImplementedError', message, 'Not Implemented', message, description)
   }
 }

--- a/solardoc/frontend/src/plugins/constants.ts
+++ b/solardoc/frontend/src/plugins/constants.ts
@@ -32,8 +32,8 @@ export default Object.freeze({
     newFile: {
       title: 'New file created',
       text:
-        "A new file has been created in your local storage! Please click 'Save in profile' to save this file " +
-        'on the server if you wish to do so!',
+        "A new file has been created in your local storage! Please note that only one concurrent file can be saved" +
+        "locally and you should save your file to avoid losing it.",
     },
     loggedOut: {
       title: 'You have been successfully logged out',

--- a/solardoc/frontend/src/plugins/constants.ts
+++ b/solardoc/frontend/src/plugins/constants.ts
@@ -29,11 +29,23 @@ export default Object.freeze({
       title: 'File uploaded and saved',
       text: "Your file has been uploaded successfully. To save a new version, click 'Save in profile'.",
     },
+    fileGone: {
+      title: 'File not found',
+      text: 'The file you are looking for does not exist or has been moved. Please check the file path and try again.',
+    },
+    successfullyOpenedSharedFile: {
+      title: 'Shared File opened',
+      text: 'The shared file has been successfully opened! Please note that you are not the owner of this file and without this URL you cannot access it again.',
+    },
     newFile: {
       title: 'New file created',
       text:
         'A new file has been created in your local storage! Please note that only one concurrent file can be saved' +
         'locally and you should save your file to avoid losing it.',
+    },
+    sharedFileIsOwnedByYou: {
+      title: 'You are the owner of this file',
+      text: 'You are the owner of this file and do not need to request access to it.',
     },
     loggedOut: {
       title: 'You have been successfully logged out',

--- a/solardoc/frontend/src/plugins/constants.ts
+++ b/solardoc/frontend/src/plugins/constants.ts
@@ -32,8 +32,8 @@ export default Object.freeze({
     newFile: {
       title: 'New file created',
       text:
-        "A new file has been created in your local storage! Please note that only one concurrent file can be saved" +
-        "locally and you should save your file to avoid losing it.",
+        'A new file has been created in your local storage! Please note that only one concurrent file can be saved' +
+        'locally and you should save your file to avoid losing it.',
     },
     loggedOut: {
       title: 'You have been successfully logged out',

--- a/solardoc/frontend/src/router/404-err.ts
+++ b/solardoc/frontend/src/router/404-err.ts
@@ -1,0 +1,13 @@
+import type { Router } from 'vue-router'
+import { useLoadingStore } from '@/stores/loading'
+
+const loadingStore = useLoadingStore()
+
+/**
+ * Throws a 404 error by redirecting the user to the 404 page.
+ * @param $router The router object.
+ */
+export function throw404Error($router: Router): Promise<any> {
+  loadingStore.setLoading(false)
+  return $router.push('/404')
+}

--- a/solardoc/frontend/src/router/index.ts
+++ b/solardoc/frontend/src/router/index.ts
@@ -1,4 +1,9 @@
-import {createRouter, createWebHistory, type NavigationFailure, type RouteLocationNormalized} from 'vue-router'
+import {
+  createRouter,
+  createWebHistory,
+  type NavigationFailure,
+  type RouteLocationNormalized,
+} from 'vue-router'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotification } from '@kyvg/vue3-notification'
 import HomeView from '../views/HomeView.vue'
@@ -122,7 +127,11 @@ router.afterEach(() => {
   loadingStore.setLoading(false)
 })
 
-function reportRouterFailure(to: RouteLocationNormalized, from: RouteLocationNormalized, failure: NavigationFailure) {
+function reportRouterFailure(
+  to: RouteLocationNormalized,
+  from: RouteLocationNormalized,
+  failure: NavigationFailure,
+) {
   console.error(`Failed to navigate from ${from.fullPath} to ${to.fullPath}:`, failure)
 }
 

--- a/solardoc/frontend/src/router/index.ts
+++ b/solardoc/frontend/src/router/index.ts
@@ -80,7 +80,7 @@ const router = createRouter({
           sensitive: true,
           strict: true,
         },
-      ]
+      ],
     },
     // ---- DEPRECATED ----
     {

--- a/solardoc/frontend/src/router/index.ts
+++ b/solardoc/frontend/src/router/index.ts
@@ -68,7 +68,7 @@ const router = createRouter({
         },
         {
           name: 'remote-editor',
-          path: ':fileId',
+          path: 'o/:fileId',
           component: () => import('@/views/EditorView.vue'),
           sensitive: true,
           strict: true,

--- a/solardoc/frontend/src/router/index.ts
+++ b/solardoc/frontend/src/router/index.ts
@@ -28,11 +28,6 @@ const router = createRouter({
       component: () => import('@/views/CollabView.vue'),
     },
     {
-      path: '/editor' + htmlExtMatcher,
-      name: 'editor',
-      component: () => import('@/views/EditorView.vue'),
-    },
-    {
       path: '/login' + htmlExtMatcher,
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
@@ -58,10 +53,42 @@ const router = createRouter({
       component: () => import('@/views/TestEditorView.vue'),
     },
     {
+      path: '/editor',
+      children: [
+        {
+          path: '',
+          redirect: { name: 'local-editor' },
+        },
+        {
+          name: 'local-editor',
+          path: 'local',
+          component: () => import('@/views/EditorView.vue'),
+          sensitive: true,
+          strict: true,
+        },
+        {
+          name: 'remote-editor',
+          path: ':fileId',
+          component: () => import('@/views/EditorView.vue'),
+          sensitive: true,
+          strict: true,
+        },
+        {
+          name: 'shared-editor',
+          path: 'shared/:fileId',
+          component: () => import('@/views/EditorView.vue'),
+          sensitive: true,
+          strict: true,
+        },
+      ]
+    },
+    // ---- DEPRECATED ----
+    {
       path: '/share/:shareUrlId',
       name: 'share-url',
       component: () => import('@/views/ShareURLView.vue'),
     },
+    // ---------------------
     // 404-page (reroutes in the view to the static 404.html)
     {
       path: '/404',

--- a/solardoc/frontend/src/router/index.ts
+++ b/solardoc/frontend/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import {createRouter, createWebHistory, type NavigationFailure, type RouteLocationNormalized} from 'vue-router'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotification } from '@kyvg/vue3-notification'
 import HomeView from '../views/HomeView.vue'
@@ -120,6 +120,16 @@ router.beforeResolve((to, from, next) => {
 router.afterEach(() => {
   const loadingStore = useLoadingStore()
   loadingStore.setLoading(false)
+})
+
+function reportRouterFailure(to: RouteLocationNormalized, from: RouteLocationNormalized, failure: NavigationFailure) {
+  console.error(`Failed to navigate from ${from.fullPath} to ${to.fullPath}:`, failure)
+}
+
+router.afterEach((to, from, failure) => {
+  if (failure) {
+    reportRouterFailure(to, from, failure)
+  }
 })
 
 export default router

--- a/solardoc/frontend/src/router/omit-query.ts
+++ b/solardoc/frontend/src/router/omit-query.ts
@@ -1,0 +1,18 @@
+import type {LocationQuery, Router} from "vue-router";
+
+/**
+ * Omits the specified query key from the current route.
+ * @param $router The router to use to redirect to the editor.
+ * @param options The options to use to omit the query key.
+ */
+export function omitQuery($router: Router, options: { queryKey: string | Array<string>}) {
+  const newQuery: LocationQuery = {}
+  const query = $router.currentRoute.value.query
+  const queryKey = Array.isArray(options.queryKey) ? options.queryKey : [options.queryKey]
+  for (const key in query) {
+    if (!queryKey.includes(key)) {
+      newQuery[key] = query[key]
+    }
+  }
+  return $router.push({ query: newQuery })
+}

--- a/solardoc/frontend/src/router/omit-query.ts
+++ b/solardoc/frontend/src/router/omit-query.ts
@@ -1,11 +1,11 @@
-import type {LocationQuery, Router} from "vue-router";
+import type { LocationQuery, Router } from 'vue-router'
 
 /**
  * Omits the specified query key from the current route.
  * @param $router The router to use to redirect to the editor.
  * @param options The options to use to omit the query key.
  */
-export function omitQuery($router: Router, options: { queryKey: string | Array<string>}) {
+export function omitQuery($router: Router, options: { queryKey: string | Array<string> }) {
   const newQuery: LocationQuery = {}
   const query = $router.currentRoute.value.query
   const queryKey = Array.isArray(options.queryKey) ? options.queryKey : [options.queryKey]

--- a/solardoc/frontend/src/router/open.ts
+++ b/solardoc/frontend/src/router/open.ts
@@ -1,17 +1,11 @@
-import type {RouteLocationRaw, Router} from "vue-router";
+import type { RouteLocationRaw, Router } from 'vue-router'
 
 /**
  * Opens a new window with the given route.
  * @param $router The router which stores the route that should be navigated to.
  * @param routeTo The location to navigate to.
  */
-export function openInNewWindow(
-  $router: Router,
-  routeTo: RouteLocationRaw
-) {
-  const routeData = $router.resolve(routeTo);
-  window.open(
-    routeData.href,
-    '_blank'
-  );
+export function openInNewWindow($router: Router, routeTo: RouteLocationRaw) {
+  const routeData = $router.resolve(routeTo)
+  window.open(routeData.href, '_blank')
 }

--- a/solardoc/frontend/src/router/open.ts
+++ b/solardoc/frontend/src/router/open.ts
@@ -1,0 +1,17 @@
+import type {RouteLocationRaw, Router} from "vue-router";
+
+/**
+ * Opens a new window with the given route.
+ * @param $router The router which stores the route that should be navigated to.
+ * @param routeTo The location to navigate to.
+ */
+export function openInNewWindow(
+  $router: Router,
+  routeTo: RouteLocationRaw
+) {
+  const routeData = $router.resolve(routeTo);
+  window.open(
+    routeData.href,
+    '_blank'
+  );
+}

--- a/solardoc/frontend/src/scripts/editor/editor.ts
+++ b/solardoc/frontend/src/scripts/editor/editor.ts
@@ -241,7 +241,9 @@ export class SolardocEditor {
 
       currentFileStore.resetLastModified()
       const changeOTUpdates = await createOTUpdates(event.changes)
-      await sendOTUpdates(changeOTUpdates, editorUpdateWSClient.hasActiveChannelConnection)
+
+      // Voiding the promise here to avoid the need to await it and avoiding blocking the editor UI
+      void sendOTUpdates(changeOTUpdates, editorUpdateWSClient.hasActiveChannelConnection)
     })
   }
 

--- a/solardoc/frontend/src/scripts/editor/file.ts
+++ b/solardoc/frontend/src/scripts/editor/file.ts
@@ -12,12 +12,11 @@ import { usePreviewLoadingStore } from '@/stores/preview-loading'
 import { useInitStateStore } from '@/stores/init-state'
 import * as phoenixBackend from '@/services/phoenix/api-service'
 import { SolardocUnreachableError } from '@/errors/unreachable-error'
-import { SolardocNotImplementedError } from '@/errors/not-implemented-error'
 import { KipperFileNotFoundError } from '@/errors/file-not-found-error'
-import {showSuccessNotifFromObj, showWarnNotifFromObj} from '@/scripts/show-notif'
+import { showSuccessNotifFromObj, showWarnNotifFromObj } from '@/scripts/show-notif'
 import constants from '@/plugins/constants'
-import {initEditorFileBasedOnShareURL} from "@/scripts/share/resolve-share-url";
-import {omitQuery} from "@/router/omit-query";
+import { initEditorFileBasedOnShareURL } from '@/scripts/share/resolve-share-url'
+import { omitQuery } from '@/router/omit-query'
 
 const currentFileStore = useCurrentFileStore()
 const currentUserStore = useCurrentUserStore()

--- a/solardoc/frontend/src/scripts/editor/file.ts
+++ b/solardoc/frontend/src/scripts/editor/file.ts
@@ -1,21 +1,21 @@
-import {useCurrentFileStore} from '@/stores/current-file'
-import {useCurrentUserStore} from '@/stores/current-user'
-import {useEditorUpdateWSClient} from '@/stores/editor-update-ws-client'
-import {useOverlayStateStore} from '@/stores/overlay-state'
-import {connectToWSIfPossible} from '@/scripts/editor/sds'
-import {createOrJoinChannelForFile} from '@/scripts/editor/channel'
-import {useLoadingStore} from '@/stores/loading'
-import {useRenderDataStore} from '@/stores/render-data'
-import type {File} from '@/services/phoenix/gen/phoenix-rest-service'
-import type {LocationQuery, RouteParams, Router} from 'vue-router'
-import {usePreviewLoadingStore} from '@/stores/preview-loading'
-import {useInitStateStore} from '@/stores/init-state'
+import { useCurrentFileStore } from '@/stores/current-file'
+import { useCurrentUserStore } from '@/stores/current-user'
+import { useEditorUpdateWSClient } from '@/stores/editor-update-ws-client'
+import { useOverlayStateStore } from '@/stores/overlay-state'
+import { connectToWSIfPossible } from '@/scripts/editor/sds'
+import { createOrJoinChannelForFile } from '@/scripts/editor/channel'
+import { useLoadingStore } from '@/stores/loading'
+import { useRenderDataStore } from '@/stores/render-data'
+import type { File } from '@/services/phoenix/gen/phoenix-rest-service'
+import type { LocationQuery, RouteParams, Router } from 'vue-router'
+import { usePreviewLoadingStore } from '@/stores/preview-loading'
+import { useInitStateStore } from '@/stores/init-state'
 import * as phoenixBackend from '@/services/phoenix/api-service'
-import {SolardocUnreachableError} from "@/errors/unreachable-error";
-import {SolardocNotImplementedError} from "@/errors/not-implemented-error";
-import {KipperFileNotFoundError} from "@/errors/file-not-found-error";
-import {showSuccessNotifFromObj} from "@/scripts/show-notif";
-import constants from "@/plugins/constants";
+import { SolardocUnreachableError } from '@/errors/unreachable-error'
+import { SolardocNotImplementedError } from '@/errors/not-implemented-error'
+import { KipperFileNotFoundError } from '@/errors/file-not-found-error'
+import { showSuccessNotifFromObj } from '@/scripts/show-notif'
+import constants from '@/plugins/constants'
 
 const currentFileStore = useCurrentFileStore()
 const currentUserStore = useCurrentUserStore()
@@ -42,7 +42,6 @@ export async function initEditorFileBasedOnPath(
   routeQueries: LocationQuery,
 ): Promise<'local' | ['remote', string] | ['shared', string]> {
   if ('showFileGoneError' in routeQueries && routeQueries.showFileGoneError === 'true') {
-
   }
 
   if (routeName === 'local-editor') {
@@ -51,7 +50,7 @@ export async function initEditorFileBasedOnPath(
 
       // We need to avoid the user reloading the page and accidentally clearing his state so we need to clean up the
       // path query and ensure that the reload is without side effects
-      $router.push({name: 'local-editor'}).then(() => {
+      $router.push({ name: 'local-editor' }).then(() => {
         showSuccessNotifFromObj(constants.notifMessages.newFile)
       })
     } else {
@@ -66,7 +65,7 @@ export async function initEditorFileBasedOnPath(
       await currentFileStore.setFileWithRemoteId(id, currentUserStore.bearer!)
     } catch (e) {
       if (e instanceof KipperFileNotFoundError) {
-        await $router.push({name: 'local-editor', query: {showFileGoneError: 'true'}})
+        await $router.push({ name: 'local-editor', query: { showFileGoneError: 'true' } })
       }
     }
     await phoenixBackend.ensurePhoenixBackendIsReachable()
@@ -91,7 +90,7 @@ export async function openFileInEditor($router: Router, file: File): Promise<voi
   previewLoadingStore.setPreviewLoading(false)
 
   await closeEditorRemoteFileConnection()
-  await currentFileStore.closeFileGlobally({emptyContent: true})
+  await currentFileStore.closeFileGlobally({ emptyContent: true })
   await $router.push(`/editor/o/${file.id}`)
 }
 
@@ -120,9 +119,7 @@ export async function createEditorRemoteFileConnection(): Promise<void> {
   overlayStateStore.resetAll()
   const sdsConnected = await connectToWSIfPossible()
   if (!sdsConnected) {
-    throw new SolardocUnreachableError(
-      'Failed to establish connection to the remote SDS server',
-    )
+    throw new SolardocUnreachableError('Failed to establish connection to the remote SDS server')
   }
   await createOrJoinChannelForFile(
     <File>currentFileStore.raw, // Since this is a remote file we know it's not a LocalFile

--- a/solardoc/frontend/src/scripts/share/resolve-share-url.ts
+++ b/solardoc/frontend/src/scripts/share/resolve-share-url.ts
@@ -7,14 +7,13 @@ import type {
 import type { Awaited } from '@vueuse/core'
 import * as phoenixRestService from '@/services/phoenix/api-service'
 import { PhoenixInternalError } from '@/services/phoenix/errors'
-import {showWarnNotif, showWarnNotifFromObj} from '@/scripts/show-notif'
+import { showWarnNotif } from '@/scripts/show-notif'
 import type { Permission } from '@/stores/current-file'
 import { useCurrentFileStore } from '@/stores/current-file'
 import { useCurrentUserStore } from '@/stores/current-user'
 import type { Router } from 'vue-router'
 import { throw404Error } from '@/router/404-err'
 import { useLoadingStore } from '@/stores/loading'
-import constants from "@/plugins/constants";
 
 const loadingStore = useLoadingStore()
 const currentFileStore = useCurrentFileStore()
@@ -108,7 +107,10 @@ async function getFilePermissionsForCurrentUser(file: File): Promise<FilePermiss
  * @returns True if the file was successfully initialized, false otherwise (indicates an error or redirect to login).
  * @since 1.0.0
  */
-export async function initEditorFileBasedOnShareURL($router: Router, shareUrlId: string): Promise<boolean> {
+export async function initEditorFileBasedOnShareURL(
+  $router: Router,
+  shareUrlId: string,
+): Promise<boolean> {
   if (!shareUrlId) {
     await $router.isReady()
     await $router.push('/404')
@@ -136,12 +138,11 @@ export async function initEditorFileBasedOnShareURL($router: Router, shareUrlId:
   const isShareFileOwner = currentUserStore.currentUser?.id === file.owner_id
   if (isShareFileOwner) {
     await $router.isReady()
-    await $router.replace({ path: `/editor/o/${file.id}`, force: true, query: { showIsOwnerWarn: 'true' } })
-      .then(
-        () => {
-          $router.go(0) // Reload the page to ensure the file is loaded, due to a bug this is necessary
-        }
-      )
+    await $router
+      .replace({ path: `/editor/o/${file.id}`, force: true, query: { showIsOwnerWarn: 'true' } })
+      .then(() => {
+        $router.go(0) // Reload the page to ensure the file is loaded, due to a bug this is necessary
+      })
     return false
   }
   const permissions = await getFilePermissionsForUser($router, file, shareURL.perms)

--- a/solardoc/frontend/src/scripts/share/resolve-share-url.ts
+++ b/solardoc/frontend/src/scripts/share/resolve-share-url.ts
@@ -1,0 +1,150 @@
+import type {
+  CreateFilePermissions,
+  File,
+  FilePermission,
+  ShareUrl,
+} from '@/services/phoenix/gen/phoenix-rest-service'
+import type { Awaited } from '@vueuse/core'
+import * as phoenixRestService from '@/services/phoenix/api-service'
+import { PhoenixInternalError } from '@/services/phoenix/errors'
+import {showWarnNotif, showWarnNotifFromObj} from '@/scripts/show-notif'
+import type { Permission } from '@/stores/current-file'
+import { useCurrentFileStore } from '@/stores/current-file'
+import { useCurrentUserStore } from '@/stores/current-user'
+import type { Router } from 'vue-router'
+import { throw404Error } from '@/router/404-err'
+import { useLoadingStore } from '@/stores/loading'
+import constants from "@/plugins/constants";
+
+const loadingStore = useLoadingStore()
+const currentFileStore = useCurrentFileStore()
+const currentUserStore = useCurrentUserStore()
+
+async function getFile($router: Router, shareUrlId: string): Promise<File | undefined> {
+  let resp: Awaited<ReturnType<typeof phoenixRestService.getV2ShareByIdFile>>
+  try {
+    resp = await phoenixRestService.getV2ShareByIdFile(currentUserStore.bearer!, shareUrlId)
+  } catch (e) {
+    throw new PhoenixInternalError('Critically failed to fetch file. Cause: ' + (<Error>e).message)
+  }
+
+  if (resp.status !== 200) {
+    await throw404Error($router)
+    return undefined
+  }
+  return resp.data
+}
+
+async function getShareURL($router: Router, shareUrlId: string): Promise<ShareUrl | undefined> {
+  let resp: Awaited<ReturnType<typeof phoenixRestService.getV2ShareById>>
+  try {
+    resp = await phoenixRestService.getV2ShareById(currentUserStore.bearer!, shareUrlId)
+  } catch (e) {
+    throw new PhoenixInternalError(
+      'Critically failed to fetch share URL. Cause: ' + (<Error>e).message,
+    )
+  }
+
+  if (resp.status !== 200) {
+    await throw404Error($router)
+    return undefined
+  }
+  return resp.data
+}
+
+async function getFilePermissionsForUser(
+  $router: Router,
+  file: File,
+  permissionsFromUrl: number,
+): Promise<number> {
+  const perm: FilePermission | undefined = await getFilePermissionsForCurrentUser(file)
+  if (perm !== undefined) {
+    return perm.permission
+  }
+  await createFilePermission($router, file, permissionsFromUrl)
+  return permissionsFromUrl
+}
+
+async function createFilePermission($router: Router, file: File, permissionsFromUrl: number) {
+  try {
+    const createFilePermissions: CreateFilePermissions = {
+      permission: permissionsFromUrl,
+      file_id: file.id,
+      user_id: currentUserStore.currentUser?.id!,
+    }
+    await phoenixRestService.postV2FilesPermissions(currentUserStore.bearer!, createFilePermissions)
+  } catch (e) {
+    throw new PhoenixInternalError(
+      'Critically failed to create permissions entry. Cause: ' + (<Error>e).message,
+    )
+  }
+}
+
+async function getFilePermissionsForCurrentUser(file: File): Promise<FilePermission | undefined> {
+  let currentUserFilePermissions: Awaited<
+    ReturnType<typeof phoenixRestService.getV2FilesByFileIdPermissionsAndUserId>
+  >
+  try {
+    currentUserFilePermissions = await phoenixRestService.getV2FilesByFileIdPermissionsAndUserId(
+      currentUserStore.bearer!,
+      file.id,
+      currentUserStore.currentUser?.id!,
+    )
+    if (currentUserFilePermissions.status === 404) {
+      return undefined
+    }
+  } catch (e) {
+    throw new PhoenixInternalError(
+      'Critically failed to fetch file permission. Cause: ' + (<Error>e).message,
+    )
+  }
+  return <FilePermission>currentUserFilePermissions.data
+}
+
+/**
+ * Handles a share URL and initializes the editor based on the share URL.
+ * @param $router The router object.
+ * @param shareUrlId The share URL ID.
+ * @returns True if the file was successfully initialized, false otherwise (indicates an error or redirect to login).
+ * @since 1.0.0
+ */
+export async function initEditorFileBasedOnShareURL($router: Router, shareUrlId: string): Promise<boolean> {
+  if (!shareUrlId) {
+    await $router.isReady()
+    await $router.push('/404')
+    return false
+  } else if (!currentUserStore.loggedIn) {
+    loadingStore.setLoading(false)
+    await $router.push({ path: '/login', query: { returnTo: $router.currentRoute.value.fullPath } })
+    showWarnNotif(
+      'Not logged in',
+      'You need to be logged in to view this file. Please log in first and try again.',
+    )
+    return false
+  }
+
+  const file = await getFile($router, shareUrlId)
+  if (!file) {
+    return false
+  }
+  const shareURL = await getShareURL($router, shareUrlId)
+  if (!shareURL) {
+    return false
+  }
+
+  // The owner themselves can use the share URL so we need to make sure they see it as it were their own file
+  const isShareFileOwner = currentUserStore.currentUser?.id === file.owner_id
+  if (isShareFileOwner) {
+    await $router.isReady()
+    await $router.replace({ path: `/editor/o/${file.id}`, force: true, query: { showIsOwnerWarn: 'true' } })
+      .then(
+        () => {
+          $router.go(0) // Reload the page to ensure the file is loaded, due to a bug this is necessary
+        }
+      )
+    return false
+  }
+  const permissions = await getFilePermissionsForUser($router, file, shareURL.perms)
+  currentFileStore.setFileFromShared(file, shareUrlId, <Permission>permissions)
+  return true
+}

--- a/solardoc/frontend/src/scripts/show-notif.ts
+++ b/solardoc/frontend/src/scripts/show-notif.ts
@@ -51,6 +51,10 @@ export function showInfoNotif(title: string, text: string): void {
   showNotif('info', title, text)
 }
 
+export function showSuccessNotifFromObj(obj: { title: string; text: string }): void {
+  showSuccessNotif(obj.title, obj.text)
+}
+
 export function showSuccessNotif(title: string, text: string): void {
   showNotif('success', title, text)
 }

--- a/solardoc/frontend/src/scripts/show-notif.ts
+++ b/solardoc/frontend/src/scripts/show-notif.ts
@@ -5,8 +5,8 @@ export type NotificationType = Exclude<NotificationsOptions['type'], undefined>
 const duration: Record<NotificationType, number> = {
   error: 20000,
   warn: 15000,
-  info: 10000,
-  success: 5000,
+  info: 12000,
+  success: 10000,
 }
 const { notify } = useNotification()
 
@@ -35,8 +35,12 @@ export function showErrorNotif(title: string, text: string): void {
   showNotif('error', title, text)
 }
 
-function showWarnNotifFromErr(error: NotifiableError & { isWarn: true }): void {
+export function showWarnNotifFromErr(error: NotifiableError & { isWarn: true }): void {
   showWarnNotif(`${error.notifName}: ${error.notifMessage}`, error.notifDescription)
+}
+
+export function showWarnNotifFromObj(obj: { title: string; text: string }): void {
+  showWarnNotif(obj.title, obj.text)
 }
 
 export function showWarnNotif(title: string, text: string): void {

--- a/solardoc/frontend/src/scripts/wait-for.ts
+++ b/solardoc/frontend/src/scripts/wait-for.ts
@@ -1,0 +1,34 @@
+/**
+ * Waits until a specific condition is met and then executes a specific request.
+ * @param cond A function that returns a boolean indicating whether the condition is met.
+ * @param callback A function that represents the request to be executed.
+ * @param interval The interval in milliseconds to check the condition.
+ * @param timeout The timeout in milliseconds to wait for the condition to be met.
+ */
+export async function waitForConditionAndExecute(
+  cond: () => boolean,
+  callback: () => Promise<void>,
+  interval: number,
+  timeout?: number | undefined
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const checkCondition = async () => {
+      if (cond()) {
+        try {
+          await callback();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      } else if (timeout && Date.now() - startTime >= timeout) {
+        reject(new Error('Timeout exceeded'));
+      } else {
+        setTimeout(checkCondition, interval);
+      }
+    };
+
+    checkCondition();
+  });
+}

--- a/solardoc/frontend/src/scripts/wait-for.ts
+++ b/solardoc/frontend/src/scripts/wait-for.ts
@@ -9,26 +9,26 @@ export async function waitForConditionAndExecute(
   cond: () => boolean,
   callback: () => Promise<void>,
   interval: number,
-  timeout?: number | undefined
+  timeout?: number | undefined,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const startTime = Date.now();
+    const startTime = Date.now()
 
     const checkCondition = async () => {
       if (cond()) {
         try {
-          await callback();
-          resolve();
+          await callback()
+          resolve()
         } catch (error) {
-          reject(error);
+          reject(error)
         }
       } else if (timeout && Date.now() - startTime >= timeout) {
-        reject(new Error('Timeout exceeded'));
+        reject(new Error('Timeout exceeded'))
       } else {
-        setTimeout(checkCondition, interval);
+        setTimeout(checkCondition, interval)
       }
-    };
+    }
 
-    checkCondition();
-  });
+    checkCondition()
+  })
 }

--- a/solardoc/frontend/src/services/phoenix/gen/phoenix-rest-service.ts
+++ b/solardoc/frontend/src/services/phoenix/gen/phoenix-rest-service.ts
@@ -6,6 +6,7 @@
  */
 import * as Oazapfts from 'oazapfts/lib/runtime'
 import * as QS from 'oazapfts/lib/runtime/query'
+
 export const defaults: Oazapfts.RequestOpts = {
   baseUrl: 'http://localhost:4000/phx/api',
 }

--- a/solardoc/frontend/src/services/render/gen/backend-rest-service.ts
+++ b/solardoc/frontend/src/services/render/gen/backend-rest-service.ts
@@ -6,6 +6,7 @@
  */
 import * as Oazapfts from 'oazapfts/lib/runtime'
 import * as QS from 'oazapfts/lib/runtime/query'
+
 export const defaults: Oazapfts.RequestOpts = {
   baseUrl: '/',
 }

--- a/solardoc/frontend/src/stores/current-file.ts
+++ b/solardoc/frontend/src/stores/current-file.ts
@@ -12,7 +12,7 @@ import constants from '@/plugins/constants'
 import { showNotifFromErr } from '@/scripts/show-notif'
 import { FileGoneWarn } from '@/errors/file-gone-warn'
 import { isDev } from '@/config/env'
-import {KipperFileNotFoundError} from "@/errors/file-not-found-error";
+import { KipperFileNotFoundError } from '@/errors/file-not-found-error'
 
 export type Unknown = null
 export type NoPermissions = 0
@@ -47,10 +47,7 @@ export interface LocalFile {
   is_global: boolean
 }
 
-function getDefaultFile(
-  currentUserId?: string,
-  empty?: boolean,
-): LocalFile | File {
+function getDefaultFile(currentUserId?: string, empty?: boolean): LocalFile | File {
   return {
     id: undefined,
     content: empty ? '' : constants.defaultFileContent,
@@ -529,12 +526,7 @@ export const useCurrentFileStore = defineStore('currentFile', {
      * @param options.emptyContent If true, the content will be reset to an empty string.
      * @since 0.7.0
      */
-    async closeFileGlobally(
-      options?: {
-        preserveContent?: boolean,
-        emptyContent?: boolean,
-      }
-    ) {
+    async closeFileGlobally(options?: { preserveContent?: boolean; emptyContent?: boolean }) {
       this.clearFileId()
       this.clearOTransStack()
       this.clearOwnerId()

--- a/solardoc/frontend/src/stores/current-file.ts
+++ b/solardoc/frontend/src/stores/current-file.ts
@@ -9,8 +9,6 @@ import {
   PhoenixNotAuthorisedError,
 } from '@/services/phoenix/errors'
 import constants from '@/plugins/constants'
-import { showNotifFromErr } from '@/scripts/show-notif'
-import { FileGoneWarn } from '@/errors/file-gone-warn'
 import { isDev } from '@/config/env'
 import { KipperFileNotFoundError } from '@/errors/file-not-found-error'
 

--- a/solardoc/frontend/src/stores/current-file.ts
+++ b/solardoc/frontend/src/stores/current-file.ts
@@ -12,6 +12,7 @@ import constants from '@/plugins/constants'
 import { showNotifFromErr } from '@/scripts/show-notif'
 import { FileGoneWarn } from '@/errors/file-gone-warn'
 import { isDev } from '@/config/env'
+import {KipperFileNotFoundError} from "@/errors/file-not-found-error";
 
 export type Unknown = null
 export type NoPermissions = 0
@@ -208,6 +209,13 @@ export const useCurrentFileStore = defineStore('currentFile', {
   },
   actions: {
     /**
+     * Resets the store and sets the content to the default file content.
+     * @since 1.0.0
+     */
+    setFileToDefaultState(currentUserId?: string, empty?: boolean) {
+      this.setFile(getDefaultFile(currentUserId, empty))
+    },
+    /**
      * Loads the data from the local storage into the store.
      *
      * This will fall back to a default file in case the local storage is empty or the data is corrupted.
@@ -262,10 +270,7 @@ export const useCurrentFileStore = defineStore('currentFile', {
       if (resp.status === 200) {
         this.setFile(resp.data)
       } else {
-        await this.closeFileGlobally({ preserveContent: true })
-
-        // Show notification indicating that the file was not found
-        showNotifFromErr(new FileGoneWarn())
+        throw new KipperFileNotFoundError()
       }
     },
     /**

--- a/solardoc/frontend/src/views/EditorView.vue
+++ b/solardoc/frontend/src/views/EditorView.vue
@@ -1,17 +1,16 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import {useRoute, useRouter} from "vue-router";
+import { useRoute, useRouter } from 'vue-router'
 import { useCurrentUserStore } from '@/stores/current-user'
 import FullScreenPreview from '@/components/editor/FullScreenPreview.vue'
 import ChannelView from '@/components/editor/dropdown/current-channel/CurrentChannelWrapper.vue'
 import ShareUrlCreate from '@/components/editor/dropdown/share-url/ShareUrlCreate.vue'
 import Export from '@/components/editor/export/Export.vue'
 import * as backendAPI from '@/services/render/api-service'
-import * as phoenixBackend from '@/services/phoenix/api-service'
 import { showWelcomeIfNeverShownBefore } from '@/scripts/show-welcome'
 import { interceptErrors } from '@/errors/handler/error-handler'
 import EditorSettings from '@/components/editor/dropdown/editor-settings/EditorSettings.vue'
-import {createEditorRemoteFileConnection, initEditorFileBasedOnPath} from '@/scripts/editor/file'
+import { initEditorFileBasedOnPath } from '@/scripts/editor/file'
 import { useLoadingStore } from '@/stores/loading'
 import DefaultEditorSubView from '@/components/editor/sub-views/default/DefaultEditorSubView.vue'
 import FullScreenEditor from '@/components/editor/sub-views/full-screen-editor/FullScreenEditor.vue'
@@ -51,7 +50,12 @@ const fileStateInitialised = ref(false)
 const fileType = ref<Awaited<ReturnType<typeof initEditorFileBasedOnPath>>>('local')
 interceptErrors(
   (async () => {
-    fileType.value = await initEditorFileBasedOnPath($router, <string>$route.name, $route.params, $route.query)
+    fileType.value = await initEditorFileBasedOnPath(
+      $router,
+      <string>$route.name,
+      $route.params,
+      $route.query,
+    )
     fileStateInitialised.value = true
     loadingStore.setLoading(false)
   })(),

--- a/solardoc/frontend/src/views/EditorView.vue
+++ b/solardoc/frontend/src/views/EditorView.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import {useRoute} from "vue-router";
+import {useRoute, useRouter} from "vue-router";
 import { useCurrentUserStore } from '@/stores/current-user'
 import FullScreenPreview from '@/components/editor/FullScreenPreview.vue'
 import ChannelView from '@/components/editor/dropdown/current-channel/CurrentChannelWrapper.vue'
@@ -24,6 +24,7 @@ import {
 import constants from '@/plugins/constants'
 import EditorNavbar from '@/components/editor/editor-navbar/EditorNavbar.vue'
 
+const $router = useRouter()
 const $route = useRoute()
 const currentUserStore = useCurrentUserStore()
 const loadingStore = useLoadingStore()
@@ -50,7 +51,7 @@ const fileStateInitialised = ref(false)
 const fileType = ref<Awaited<ReturnType<typeof initEditorFileBasedOnPath>>>('local')
 interceptErrors(
   (async () => {
-    fileType.value = await initEditorFileBasedOnPath(<string>$route.name, $route.params)
+    fileType.value = await initEditorFileBasedOnPath($router, <string>$route.name, $route.params, $route.query)
     fileStateInitialised.value = true
     loadingStore.setLoading(false)
   })(),

--- a/solardoc/frontend/src/views/ShareURLView.vue
+++ b/solardoc/frontend/src/views/ShareURLView.vue
@@ -1,151 +1,20 @@
 <script lang="ts" setup>
 import ProgressSpinner from '@/components/common/ProgressSpinner.vue'
-import { type Permission, useCurrentFileStore } from '@/stores/current-file'
-import {
-  type File,
-  type ShareUrl,
-  type CreateFilePermissions,
-  type FilePermission,
-} from '@/services/phoenix/api-service'
-import * as phoenixRestService from '@/services/phoenix/api-service'
-import { useCurrentUserStore } from '@/stores/current-user'
-import { PhoenixInternalError } from '@/services/phoenix/errors'
-import { useLoadingStore } from '@/stores/loading'
-import { useRoute, useRouter } from 'vue-router'
-import { showWarnNotif } from '@/scripts/show-notif'
-import { interceptErrors } from '@/errors/handler/error-handler'
-import type { Awaited } from '@vueuse/core'
+import {useLoadingStore} from '@/stores/loading'
+import {useRoute, useRouter} from 'vue-router'
+import {interceptErrors} from '@/errors/handler/error-handler'
+import {initEditorFileBasedOnShareURL} from "@/scripts/share/resolve-share-url";
 
-const currentFileStore = useCurrentFileStore()
-const currentUserStore = useCurrentUserStore()
 const loadingStore = useLoadingStore()
 
 const $route = useRoute()
 const $router = useRouter()
 
 loadingStore.setLoading(true)
-
-function throw404Error(): Promise<any> {
-  return $router.push('/404')
-}
-
-async function getFile(shareUrlId: string): Promise<File | undefined> {
-  let resp: Awaited<ReturnType<typeof phoenixRestService.getV2ShareByIdFile>>
-  try {
-    resp = await phoenixRestService.getV2ShareByIdFile(currentUserStore.bearer!, shareUrlId)
-  } catch (e) {
-    throw new PhoenixInternalError('Critically failed to fetch file. Cause: ' + (<Error>e).message)
-  }
-
-  if (resp.status !== 200) {
-    await throw404Error()
-    return undefined
-  }
-  return resp.data
-}
-
-async function getShareURL(shareUrlId: string): Promise<ShareUrl | undefined> {
-  let resp: Awaited<ReturnType<typeof phoenixRestService.getV2ShareById>>
-  try {
-    resp = await phoenixRestService.getV2ShareById(currentUserStore.bearer!, shareUrlId)
-  } catch (e) {
-    throw new PhoenixInternalError(
-      'Critically failed to fetch share URL. Cause: ' + (<Error>e).message,
-    )
-  }
-
-  if (resp.status !== 200) {
-    await throw404Error()
-    return undefined
-  }
-  return resp.data
-}
-
-async function handleShareURLReq(shareUrlId: string): Promise<void> {
-  if (!shareUrlId) {
-    loadingStore.setLoading(false)
-    await $router.push('/404')
-    return
-  } else if (!currentUserStore.loggedIn) {
-    loadingStore.setLoading(false)
-    await $router.push({ path: '/login', query: { returnTo: $route.fullPath } })
-    showWarnNotif(
-      'Not logged in',
-      'You need to be logged in to view this file. Please log in first and try again.',
-    )
-    return
-  }
-
-  const file = await getFile(shareUrlId)
-  if (!file) {
-    return
-  }
-  const shareURL = await getShareURL(shareUrlId)
-  if (!shareURL) {
-    return
-  }
-
-  // The owner themselves can use the share URL so we need to make sure they see it as it were their own file
-  const isShareFileOwner = currentUserStore.currentUser?.id === file.owner_id
-  if (isShareFileOwner) {
-    currentFileStore.setFile(file)
-  } else {
-    let permissions = await getFilePermissionsForUser(file, shareURL.perms)
-    currentFileStore.setFileFromShared(file, shareUrlId, <Permission>permissions)
-  }
+interceptErrors((async () => {
+  await initEditorFileBasedOnShareURL($router, `${$route.params.shareUrlId}`)
   loadingStore.setLoading(false)
-  await $router.push({
-    path: '/editor',
-    query: isShareFileOwner ? undefined : { shareId: shareUrlId },
-  })
-}
-
-async function getFilePermissionsForUser(file: File, permissionsFromUrl: number): Promise<number> {
-  let perm: FilePermission | undefined = await getFilePermissionsForCurrentUser(file)
-  if (perm !== undefined) {
-    return perm.permission
-  }
-  await createFilePermission(file, permissionsFromUrl)
-  return permissionsFromUrl
-}
-
-async function createFilePermission(file: File, permissionsFromUrl: number) {
-  try {
-    let createFilePermissions: CreateFilePermissions = {
-      permission: permissionsFromUrl,
-      file_id: file.id,
-      user_id: currentUserStore.currentUser?.id!,
-    }
-    await phoenixRestService.postV2FilesPermissions(currentUserStore.bearer!, createFilePermissions)
-  } catch (e) {
-    throw new PhoenixInternalError(
-      'Critically failed to create permissions entry. Cause: ' + (<Error>e).message,
-    )
-  }
-}
-
-async function getFilePermissionsForCurrentUser(file: File): Promise<FilePermission | undefined> {
-  let currentUserFilePermissions: Awaited<
-    ReturnType<typeof phoenixRestService.getV2FilesByFileIdPermissionsAndUserId>
-  >
-  try {
-    currentUserFilePermissions = await phoenixRestService.getV2FilesByFileIdPermissionsAndUserId(
-      currentUserStore.bearer!,
-      file.id,
-      currentUserStore.currentUser?.id!,
-    )
-    if (currentUserFilePermissions.status === 404) {
-      return undefined
-    }
-  } catch (e) {
-    throw new PhoenixInternalError(
-      'Criticaly faild to fetch file permission. Cause: ' + (<Error>e).message,
-    )
-  }
-  return <FilePermission>currentUserFilePermissions.data
-}
-
-interceptErrors(handleShareURLReq(`${$route.params.shareUrlId}`))
+})())
 </script>
 
 <template>

--- a/solardoc/frontend/src/views/ShareURLView.vue
+++ b/solardoc/frontend/src/views/ShareURLView.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import ProgressSpinner from '@/components/common/ProgressSpinner.vue'
-import {useLoadingStore} from '@/stores/loading'
-import {useRoute, useRouter} from 'vue-router'
-import {interceptErrors} from '@/errors/handler/error-handler'
-import {initEditorFileBasedOnShareURL} from "@/scripts/share/resolve-share-url";
+import { useLoadingStore } from '@/stores/loading'
+import { useRoute, useRouter } from 'vue-router'
+import { interceptErrors } from '@/errors/handler/error-handler'
+import { initEditorFileBasedOnShareURL } from '@/scripts/share/resolve-share-url'
 
 const loadingStore = useLoadingStore()
 
@@ -11,10 +11,12 @@ const $route = useRoute()
 const $router = useRouter()
 
 loadingStore.setLoading(true)
-interceptErrors((async () => {
-  await initEditorFileBasedOnShareURL($router, `${$route.params.shareUrlId}`)
-  loadingStore.setLoading(false)
-})())
+interceptErrors(
+  (async () => {
+    await initEditorFileBasedOnShareURL($router, `${$route.params.shareUrlId}`)
+    loadingStore.setLoading(false)
+  })(),
+)
 </script>
 
 <template>

--- a/solardoc/rest-api/Dockerfile
+++ b/solardoc/rest-api/Dockerfile
@@ -8,6 +8,22 @@ RUN corepack enable
 RUN corepack use pnpm@$PNPM_VERSION
 RUN corepack install --global pnpm@$PNPM_VERSION
 
+# Install as root
+USER root
+RUN apk add --no-cache \
+chromium \
+nss \
+freetype \
+freetype-dev \
+harfbuzz \
+ca-certificates \
+ttf-freefont \
+nodejs \
+bash
+
+# Set Chromium path and switch to node user
+ENV CHROMIUM_PATH /usr/bin/chromium-browser
+
 # Set to a non-root built-in user `node`
 USER node
 
@@ -44,21 +60,6 @@ COPY --chown=node ./solardoc/rest-api ./solardoc/rest-api
 # See issue #62 (As we are not using puppeteer yet, we can ignore this)
 ARG PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_DOWNLOAD=$PUPPETEER_SKIP_DOWNLOAD
-
-# Install as root
-USER root
-RUN apk add --no-cache \
-chromium \
-nss \
-freetype \
-freetype-dev \
-harfbuzz \
-ca-certificates \
-ttf-freefont \
-nodejs
-
-# Set Chromium path and switch to node user
-ENV CHROMIUM_PATH /usr/bin/chromium-browser
 
 # Build 'asciidoc-renderer' package
 RUN pnpm install --filter @solardoc/asciidoc-renderer --frozen-lockfile


### PR DESCRIPTION
<!--
Please read through the given points and fill them out as appropriate for your changes.

Comments are marked by arrows, like in lines 1 and 5. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Development changes (Changes that do not add new features or fix bugs, but update the project in other ways)
- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] Feature (Non-breaking change which adds functionality)
- [x] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Implemented proper separation of local, remote and shared files, which allows each file to be accessed directly through a URL without having to navigate the state-machine design that was previously present in the editor where only one file could be properly opened at a time without side effects and everything was bound to a single browser-side local store.

Closes #205

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Deprecated old ShareURL system and replaced it with `/editor/share/{uuid}`
- Implemented proper separation of concerns in the editor and removed default reliance on the local storage.
- Implemented new separate local storage system for local files as part of `/editor/local`.
- Implemented route navigation for personal files using `/editor/o/{uuid}`.
- Unblocked Monaco content watchers by allowing the async lock to self-manage the outgoing requests.
- Implemented new 'New File' system which opens up a whole new tab using `/editor/local?new=true`.
- Implemented new function `waitForConditionAndExecute()` which allows the execution of a given callback after a specific condition has been met and fulfilled.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #205
- [ ] #225 (Potentially fixes this bug)
